### PR TITLE
Fix register model for Mongoid 3.1.0+

### DIFF
--- a/lib/mongoid_auto_increment_id.rb
+++ b/lib/mongoid_auto_increment_id.rb
@@ -14,6 +14,7 @@ module Mongoid
   module Document
     # define Integer for id field
     included do
+      Mongoid.register_model(self)
       field :_id, :type => Integer
     end
 

--- a/mongoid_auto_increment_id.gemspec
+++ b/mongoid_auto_increment_id.gemspec
@@ -3,7 +3,7 @@ $:.push File.expand_path("../lib", __FILE__)
 
 Gem::Specification.new do |s|
   s.name        = "mongoid_auto_increment_id"
-  s.version     = "0.6.1"
+  s.version     = "0.6.2"
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["Jason Lee"]
   s.email       = ["huacnlee@gmail.com"]
@@ -13,5 +13,5 @@ Gem::Specification.new do |s|
   s.files        = Dir.glob("lib/**/*") + %w(README.md)
   s.require_path = 'lib'
 
-  s.add_dependency "mongoid", [">= 3.0.0","< 4.1.0"]
+  s.add_dependency "mongoid", [">= 3.1.0","< 4.1.0"]
 end

--- a/spec/monkey_patch_spec.rb
+++ b/spec/monkey_patch_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+describe Mongoid::Document do
+  it 'register model' do
+    class TestModel
+      include Mongoid::Document
+    end
+    Mongoid.models.should be_include(TestModel)
+  end
+end


### PR DESCRIPTION
Mongoid 从 3.1.0 开始，在 Mongoid::Document 的 included 中做了一个注册当前 model 的操作，4.0.0 中也还是这样。详情： [3.1.x](https://github.com/mongoid/mongoid/blob/3.1.0-stable/lib/mongoid/document.rb#L14) [4.0.0](https://github.com/mongoid/mongoid/blob/master/lib/mongoid/document.rb#L33)

mongoid_auto_increment_id 中对 Mongoid::Document 的扩展也使用了 included，这样就覆盖了注册 model 的操作。不知道你是否希望继续兼容老版本的 Mongoid，如果希望兼容，那这个 pull request 还得修改修改 :)
