### PR TITLE
Fix accepts_nested_attributes_for

### DIFF
--- a/lib/mongoid_auto_increment_id.rb
+++ b/lib/mongoid_auto_increment_id.rb
@@ -63,19 +63,12 @@ module Mongoid
       end
     end
 
-    # hack id nil when Document.new
-    def identify
-      Identity.new(self).create
-      nil
-    end
+    alias_method :super_initialize, :initialize
 
-    alias_method :super_as_document, :as_document
-    def as_document
-      result = super_as_document
-      if result[ID_FIELD].blank?
-        result[ID_FIELD] = Identity.generate_id(self)
-      end
-      result
+    def initialize(attrs = nil)
+      @attributes ||= {}
+      self[ID_FIELD] = Identity.generate_id(self)
+      super_initialize attrs
     end
   end
 end

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -2,6 +2,10 @@ require "spec_helper"
 
 describe "Mongoid::AutoIncrementId" do
   describe 'Base test' do
+    before do
+      Mongoid.purge!
+    end
+
     after do
       Post.delete_all
       Tag.delete_all
@@ -9,8 +13,8 @@ describe "Mongoid::AutoIncrementId" do
       Log.delete_all
     end
   
-    it "new record Id will be nil" do
-      expect(Post.new.id).to eq nil
+    it "new record Id will be integer" do
+      expect(Post.new.id).to be_a Integer
     end
 
     it "does Id start from 1" do
@@ -39,9 +43,9 @@ describe "Mongoid::AutoIncrementId" do
       expect(p4.id - 2).to eq p2.id
     end
 
-    it "does return nil id when Model.new" do
-      expect(Post.new.id).to eq nil
-      expect(Post.new._id).to eq nil
+    it "does return id when Model.new" do
+      expect(Post.new.id).to be_a Integer
+      expect(Post.new._id).to be_a Integer
     end
 
     it "does can find data by String and Integer id" do
@@ -112,6 +116,17 @@ describe "Mongoid::AutoIncrementId" do
       expect(Log.where(:title => "test user log").first._type).to eq "UserLog"
       expect(Log.where(:title => "test tag log").count).to eq 1
       expect(Log.where(:title => "test tag log").first._type).to eq "TagLog"
+    end
+
+    context "when accepts_nested_attributes_for" do
+      before { User.accepts_nested_attributes_for :posts }
+
+      it "set association" do
+        user = User.new(:email => "t@1.com", :posts_attributes => { "0" => {:title => "This is title!"}})
+        user.save
+        user.reload
+        expect(user.posts.size).to eq(1)
+      end
     end
   end
   

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -40,7 +40,4 @@ require "models"
 
 RSpec.configure do |config|
   config.mock_with :mocha
-  config.after :suite do
-    Mongoid.purge!
-  end
 end


### PR DESCRIPTION
``` ruby
class User
  include Mongoid::Document
  field :name 
  has_many :posts

  accepts_nested_attributes_for :posts
end

class Post
  include Mongoid::Document
  field :title
  field :body

  belongs_to :user
end
```

User 保存的时候不会自动保存关联 id. 研究了 mongoid 的代码发现， mongoid 在 Model.new 的时候，id 就已经设置值了，而 mongoid_auto_increment_id 在调用 as_document 时才会设置 id ，所以出现关联 id 不会自动保存的问题。
